### PR TITLE
Revert "Bump vite from 5.1.4 to 5.1.7"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "lint-staged": "^15.2.2",
         "msw": "^2.2.2",
         "typescript": "^5.1.6",
-        "vite": "^5.1.7",
+        "vite": "^5.1.4",
         "vitest": "^1.3.1"
       },
       "engines": {
@@ -18767,9 +18767,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
-      "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
+      "integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint-staged": "^15.2.2",
     "msw": "^2.2.2",
     "typescript": "^5.1.6",
-    "vite": "^5.1.7",
+    "vite": "^5.1.4",
     "vitest": "^1.3.1"
   },
   "engines": {


### PR DESCRIPTION
Reverting Vite upgrade because it seems to be causing build issues.